### PR TITLE
Clarify string decoding helpers

### DIFF
--- a/04.deobf.md
+++ b/04.deobf.md
@@ -1,0 +1,17 @@
+# 04.deobf.js Function Reference
+
+## `decodeString(index, unused)`
+Decodes a numeric `index` into its original string value using the lookup table returned by `getStringTable`. The second argument is ignored and kept only for compatibility with the original obfuscated code.
+
+**Usage example:**
+```javascript
+const text = decodeString(0x1a3);
+```
+
+## `getStringTable()`
+Returns the full array of obfuscated string fragments used by `decodeString`.
+
+**Usage example:**
+```javascript
+const table = getStringTable();
+```

--- a/loader/04.deobf.js
+++ b/loader/04.deobf.js
@@ -1,14 +1,15 @@
 !(function () {
   "use strict";
-  function decodeString(J, F) {
-    var w = getStringTable();
+  // Lookup helper that translates numeric codes into strings.
+  function decodeString(index, unused) {
+    var lookupTable = getStringTable();
     return (
-      (decodeString = function (E, x) {
-        E = E - 0x8b;
-        var s = w[E];
-        return s;
+      (decodeString = function (adjustedIndex, unused) {
+        adjustedIndex = adjustedIndex - 0x8b;
+        var decoded = lookupTable[adjustedIndex];
+        return decoded;
       }),
-      decodeString(J, F)
+      decodeString(index, unused)
     );
   }
   ((function (stringArrayFunction, J) {
@@ -18841,8 +18842,9 @@
           )));
       })({});
     })());
+  // Provides the array of obfuscated strings referenced by decodeString.
   function getStringTable() {
-    var Zt = [
+    var stringTable = [
       "Esi",
       "Zio",
       "nhT",
@@ -22040,7 +22042,7 @@
       "TjS",
     ];
     getStringTable = function () {
-      return Zt;
+      return stringTable;
     };
     return getStringTable();
   }


### PR DESCRIPTION
## Summary
- rename parameters in decodeString for clarity
- rename string table variables and document helper
- document available helpers in 04.deobf.md

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad2a8c073c832d96e386d0e601c398