### PR TITLE
docs: annotate export module functions

### DIFF
--- a/export.md
+++ b/export.md
@@ -1,0 +1,19 @@
+
+| 檔案名稱 | 檔案用途 |
+| --- | --- |
+| export/a/APIClient.js | 重新導出 BVFramework 的 APIClient |
+| export/a/AdapterEventEmitter.js | 簡易事件管理器，用於音效事件傳遞 |
+| export/a/AnalyticsHelper.js | 重新導出 AnalyticsHelper |
+| export/a/AnimParticleSystem.js | 自訂粒子系統，控制粒子生成與動畫 |
+| export/a/AnimParticleSystemPoolHandler.js | 粒子節點回收時停止動畫 |
+| export/a/AnimParticleSystemUtils.js | 提供粒子系統使用的計算工具 |
+| export/a/Appearance.js | 不確定用途 |
+| export/a/AppState.js | 定義應用狀態並處理狀態轉換 |
+| export/a/AppStateMachine.js | 管理多個 AppState 的狀態機 |
+| export/a/AudioAdapter.js | 音效播放適配器，負責音效實例管理 |
+| export/a/AudioAdapterConstant.js | 音效適配器使用的常數設定 |
+| export/a/AudioAssetConfig.js | 音效資源載入設定 |
+| export/a/AudioConstant.js | 遊戲通用音效片段設定 |
+| export/a/AudioFactory.js | 音效物件的簡易物件池 |
+| export/a/AudioManager.js | 全局音效管理與控制 |
+| export/a/AutoSpinHandler.js | 處理自動旋轉邏輯 |

--- a/export/a/AdapterEventEmitter.js
+++ b/export/a/AdapterEventEmitter.js
@@ -9,9 +9,11 @@ if (!cc._RF.push(module, "4a843d9tZpBC5Aag4RGjJxr", "AdapterEventEmitter")) {
       this._eventPool = Object.create(null);
       this._deferCallback = T.deferCallback(this);
     }
+    // 設定一次性事件監聽器
     D.prototype.once = function (k, C, u) {
       this.on(k, C, u, true);
     };
+    // 觸發指定事件並呼叫所有監聽函式
     D.prototype.emit = function (k, C, j, G = false) {
       var V = this._eventPool;
       var Q = V[k];
@@ -40,6 +42,7 @@ if (!cc._RF.push(module, "4a843d9tZpBC5Aag4RGjJxr", "AdapterEventEmitter")) {
         Y(q);
       }
     };
+    // 監聽指定事件
     D.prototype.on = function (k, C, u, c) {
       var p = this._eventPool;
       var j = p[k];
@@ -62,6 +65,7 @@ if (!cc._RF.push(module, "4a843d9tZpBC5Aag4RGjJxr", "AdapterEventEmitter")) {
       };
       j.push(N);
     };
+    // 取消事件監聽，可依事件或函式移除
     D.prototype.off = function (k, C, u) {
       if (k !== undefined) {
         switch (typeof k) {
@@ -82,6 +86,7 @@ if (!cc._RF.push(module, "4a843d9tZpBC5Aag4RGjJxr", "AdapterEventEmitter")) {
         }
       }
     };
+    // 依事件名稱移除監聽器
     D.prototype._offByEvent = function (k, C, u) {
       var c = this._eventPool[k];
       if (c) {
@@ -94,6 +99,7 @@ if (!cc._RF.push(module, "4a843d9tZpBC5Aag4RGjJxr", "AdapterEventEmitter")) {
         }
       }
     };
+    // 依函式內容移除監聽器
     D.prototype._offByFunction = function (k, C) {
       for (var u in this._eventPool) {
         this._eventPool[u] = this._eventPool[u].filter(function (c) {
@@ -106,6 +112,7 @@ if (!cc._RF.push(module, "4a843d9tZpBC5Aag4RGjJxr", "AdapterEventEmitter")) {
   exports.default = x;
   cc._RF.pop();
 }
+// 依條件判斷是否移除指定監聽器
 function L(D, k, C) {
   return !!C && C !== D.id || !!k && k !== D.fn || (D.fn = T.emptyFunc, false);
 }

--- a/export/a/AnimParticleSystem.js
+++ b/export/a/AnimParticleSystem.js
@@ -421,6 +421,7 @@ if (!cc._RF.push(module, "3142aQR/shASo2uVaU35yUL", "AnimParticleSystem")) {
       },
       _liveParticles: []
     },
+    // 重新啟動粒子系統，必要時清除現有粒子
     resetSystem: function (p = true) {
       if (p) {
         this.stopSystem(true);
@@ -436,6 +437,7 @@ if (!cc._RF.push(module, "3142aQR/shASo2uVaU35yUL", "AnimParticleSystem")) {
         }
       }
     },
+    // 停止粒子系統，可選擇是否立即清除粒子
     stopSystem: function (p) {
       var j = this;
       if (p === undefined) {
@@ -451,6 +453,7 @@ if (!cc._RF.push(module, "3142aQR/shASo2uVaU35yUL", "AnimParticleSystem")) {
         this._liveParticles = [];
       }
     },
+    // 產生新的粒子實體
     _spawnParticle: function () {
       if (!(this._liveParticles.length >= this.particleCount)) {
         var p = this.nodePool.get();
@@ -459,24 +462,31 @@ if (!cc._RF.push(module, "3142aQR/shASo2uVaU35yUL", "AnimParticleSystem")) {
         p.getComponent(cc.Animation).play();
       }
     },
+    // 取得粒子的壽命時間
     getLife: function (p, j) {
       return (0, L.getRandomFromRange)(p, j);
     },
+    // 取得粒子的移動速度
     getSpeed: function (p, j) {
       return (0, L.getRandomFromRange)(p, j);
     },
+    // 取得粒子發射角度
     getEmissionAngle: function (p, j) {
       return (0, L.getRandomFromRange)(p, j);
     },
+    // 取得起始縮放值
     getSourceStartScale: function (p, j) {
       return (0, L.getRandomFromRange)(p, j);
     },
+    // 取得起始旋轉角度
     getSourceStartSpinAngle: function (p, j) {
       return (0, L.getRandomFromRange)(p, j);
     },
+    // 取得起始透明度
     getSourceStartAlpha: function (p, j) {
       return (0, L.getRandomFromRange)(p, j);
     },
+    // 取得起始顏色
     getSourceStartColor: function (p, j) {
       if (j.equals(cc.Color.BLACK)) {
         return p;
@@ -484,12 +494,15 @@ if (!cc._RF.push(module, "3142aQR/shASo2uVaU35yUL", "AnimParticleSystem")) {
         return new cc.Color((0, L.getRandomFromRange)(p.getR(), j.getR()), (0, L.getRandomFromRange)(p.getG(), j.getG()), (0, L.getRandomFromRange)(p.getB(), j.getB()));
       }
     },
+    // 取得起始位置
     getSourceStartPosition: function (p, j) {
       return cc.v2((0, L.getRandomFromRange)(p.x, j.x), (0, L.getRandomFromRange)(p.y, j.y));
     },
+    // 取得結束縮放值
     getSourceEndScale: function (p, j, G, V) {
       return (V ? p : 1) * (0, L.getRandomFromRange)(j, G);
     },
+    // 取得結束旋轉角度
     getSourceEndSpinAngle: function (p, j, G, V) {
       if (V) {
         return p;
@@ -497,9 +510,11 @@ if (!cc._RF.push(module, "3142aQR/shASo2uVaU35yUL", "AnimParticleSystem")) {
         return (0, L.getRandomFromRange)(j, G);
       }
     },
+    // 取得結束透明度
     getSourceEndAlpha: function (p, j, G) {
       return (0, L.getRandomFromRange)(j, G);
     },
+    // 取得結束顏色
     getSourceEndColor: function (p, j, G) {
       if (G.equals(cc.Color.BLACK)) {
         return j;
@@ -507,11 +522,13 @@ if (!cc._RF.push(module, "3142aQR/shASo2uVaU35yUL", "AnimParticleSystem")) {
         return new cc.Color((0, L.getRandomFromRange)(j.getR(), G.getR()), (0, L.getRandomFromRange)(j.getG(), G.getG()), (0, L.getRandomFromRange)(j.getB(), G.getB()));
       }
     },
+    // 計算線性移動的終點位置
     getSourceEndPositionLinear: function (p, j, G, V) {
       var Q = Math.cos(G / 180 * Math.PI) * j * V;
       var N = Math.sin(G / 180 * Math.PI) * j * V;
       return cc.v2(p.x + Q, p.y + N);
     },
+    // 計算受重力影響的移動軌跡
     getSourceEndPositionGravity: function (j, G, V, Q, N, Y) {
       var W = Math.cos(V / 180 * Math.PI) * G * Q;
       var q = Math.sin(V / 180 * Math.PI) * G * Q;
@@ -535,6 +552,7 @@ if (!cc._RF.push(module, "3142aQR/shASo2uVaU35yUL", "AnimParticleSystem")) {
       var Z7 = U > 0 ? 1 : -1;
       return [cc.v2(E - J * Z7, F - Z0), cc.v2(H - Z2 * Z7, w - Z3), cc.v2(U - Z5 * Z7, P - Z6)];
     },
+    // 建立移動動作
     getMoveAction: function (p, j, G, V, Q) {
       var N = cc.moveTo(G, j);
       if (V) {
@@ -543,6 +561,7 @@ if (!cc._RF.push(module, "3142aQR/shASo2uVaU35yUL", "AnimParticleSystem")) {
         return N;
       }
     },
+    // 建立貝茲曲線移動動作
     getBezierAction: function (p, j, G, V, Q) {
       var N = cc.bezierTo(G, j);
       if (V) {
@@ -551,6 +570,7 @@ if (!cc._RF.push(module, "3142aQR/shASo2uVaU35yUL", "AnimParticleSystem")) {
         return N;
       }
     },
+    // 建立縮放動作
     getScaleAction: function (p, j, G, V, Q, N) {
       if (!Q) {
         if (V === 0) {
@@ -566,6 +586,7 @@ if (!cc._RF.push(module, "3142aQR/shASo2uVaU35yUL", "AnimParticleSystem")) {
         return cc.sequence(cc.delayTime(V * G), cc.scaleTo(G - V * G, j).easing(Y));
       }
     },
+    // 建立旋轉動作
     getRotateAction: function (p, j, G, V, Q, N) {
       if (!Q) {
         if (V === 0) {
@@ -581,6 +602,7 @@ if (!cc._RF.push(module, "3142aQR/shASo2uVaU35yUL", "AnimParticleSystem")) {
         return cc.sequence(cc.delayTime(V * G), cc.rotateTo(G - V * G, -j).easing(Y));
       }
     },
+    // 建立漸隱動作
     getFadeAction: function (p, j, G, V, Q, N) {
       if (!Q) {
         if (V === 0) {
@@ -596,6 +618,7 @@ if (!cc._RF.push(module, "3142aQR/shASo2uVaU35yUL", "AnimParticleSystem")) {
         return cc.sequence(cc.delayTime(V * G), cc.fadeTo(G - V * G, j).easing(Y));
       }
     },
+    // 建立顏色變化動作
     getTintAction: function (p, j, G, V, Q, N) {
       if (!Q) {
         if (V === 0) {
@@ -611,6 +634,7 @@ if (!cc._RF.push(module, "3142aQR/shASo2uVaU35yUL", "AnimParticleSystem")) {
         return cc.sequence(cc.delayTime(V * G), cc.tintTo(G - V * G, j).easing(Y));
       }
     },
+    // 設定並播放粒子的所有動作
     _playParticleAction: function (j) {
       var G = this;
       var V = this.getLife(this.life, this.lifeVar);
@@ -669,10 +693,12 @@ if (!cc._RF.push(module, "3142aQR/shASo2uVaU35yUL", "AnimParticleSystem")) {
       this.node.addChild(j);
       j.runAction(Z5);
     },
+    // 內部加速度位移計算
     _accelerationDistance: function (p, j) {
       u ||= true;
       return p * 0.5 * j * j;
     },
+    // 粒子動作結束後自我銷毀
     _particleSelfDestruct: function (p) {
       var j = this._liveParticles;
       var G = j.indexOf(p);

--- a/export/a/AnimParticleSystemPoolHandler.js
+++ b/export/a/AnimParticleSystemPoolHandler.js
@@ -3,6 +3,7 @@ if (!cc._RF.push(module, "90167wb5w5JpKAkqWQq6cj8", "AnimParticleSystemPoolHandl
   exports.default = undefined;
   var K = cc.Class({
     extends: cc.Component,
+    // 節點回收時停止其動畫播放
     unuse: function () {
       var g = this.node.getComponent(cc.Animation);
       if (g) {

--- a/export/a/AnimParticleSystemUtils.js
+++ b/export/a/AnimParticleSystemUtils.js
@@ -1,8 +1,10 @@
 if (!cc._RF.push(module, "cbd06HrkTNFtbM/q+8lJvnc", "AnimParticleSystemUtils")) {
   exports.__esModule = true;
+  // 根據加速度與時間計算位移距離
   exports.getAccelerationDistance = function (K, g) {
     return K * 0.5 * g * g;
   };
+  // 在指定範圍內回傳隨機值
   exports.getRandomFromRange = function (K, g) {
     return K + g * (Math.random() - 0.5) * 2;
   };

--- a/export/a/AppState.js
+++ b/export/a/AppState.js
@@ -13,6 +13,7 @@ if (!cc._RF.push(module, "d2312uy7dZCAaD3zr1W6wqW", "AppState")) {
     k[k.End = 3] = "End";
   })(T = exports.APPStateStatus ||= {});
   var D = function () {
+    // 建構子：設定資料來源、控制器池與離開回呼
     function k(p, j, l) {
       this.name = "App State";
       this.appStateStatus = T.Ready;
@@ -42,6 +43,7 @@ if (!cc._RF.push(module, "d2312uy7dZCAaD3zr1W6wqW", "AppState")) {
       enumerable: false,
       configurable: true
     };
+    // 預留事件監聽器，可由子類別實作
     k.prototype.eventListener = function () {};
     Object.defineProperty(k.prototype, "isStateReady", C);
     Object.defineProperty(k.prototype, "isStateRunning", u);
@@ -53,19 +55,24 @@ if (!cc._RF.push(module, "d2312uy7dZCAaD3zr1W6wqW", "AppState")) {
       enumerable: false,
       configurable: true
     });
+    // 設定資料來源
     k.prototype.setDataSource = function (p) {
       this.dataSource = p;
     };
+    // 設定控制器池
     k.prototype.setControllerPool = function (p) {
       this.controllerPool = p;
     };
+    // 設定結束時的回呼函式
     k.prototype.setExitCallback = function (p) {
       this.finalCallback = p;
     };
+    // 將狀態切換為執行中
     k.prototype.run = function () {
       this.appStateStatus = T.Running;
       this.onRun();
     };
+    // 請求離開狀態
     k.prototype.exit = function (p) {
       var j = this;
       if (!this.isStateExiting && !this.isStateEnd) {
@@ -101,6 +108,7 @@ if (!cc._RF.push(module, "d2312uy7dZCAaD3zr1W6wqW", "AppState")) {
         });
       }
     };
+    // 強制離開狀態
     k.prototype.forceExit = function (p) {
       var j = this;
       this.appStateStatus = T.Exiting;
@@ -134,6 +142,7 @@ if (!cc._RF.push(module, "d2312uy7dZCAaD3zr1W6wqW", "AppState")) {
         }
       });
     };
+    // 銷毀狀態並清理參考
     k.prototype.destroy = function () {
       var p = this;
       this.onDestroy(function () {
@@ -142,6 +151,7 @@ if (!cc._RF.push(module, "d2312uy7dZCAaD3zr1W6wqW", "AppState")) {
         p.controllerPool = undefined;
       });
     };
+    // 派發事件給當前監聽器
     k.prototype.dispatchEvent = function (p, j) {
       this.eventListener(p, j);
     };

--- a/export/a/AppStateMachine.js
+++ b/export/a/AppStateMachine.js
@@ -11,6 +11,7 @@ if (!cc._RF.push(module, "99b03/f499C5qBVb5FCdxDf", "AppStateMachine")) {
     D[D.End = 3] = "End";
   })(T ||= {});
   var L = function () {
+    // 建構子：設定取得下一狀態與離開時的回呼
     function D(p) {
       this._previousAppState = undefined;
       this._currentAppState = undefined;
@@ -64,15 +65,18 @@ if (!cc._RF.push(module, "99b03/f499C5qBVb5FCdxDf", "AppStateMachine")) {
       enumerable: false,
       configurable: true
     });
+    // 設定狀態機結束時的回呼
     D.prototype.setExitAppStateMachineCallback = function (p) {
       this._exitAppStateMachineCallback = p;
     };
+    // 啟動狀態機
     D.prototype.run = function () {
       if (this.isStateReady) {
         this._stateMachineStatus = T.Running;
         this._evaluateState();
       }
     };
+    // 請求離開當前狀態機
     D.prototype.exit = function (p) {
       if (!this.isStateExiting && !this.isStateEnd) {
         this._stateMachineStatus = T.Exiting;
@@ -83,6 +87,7 @@ if (!cc._RF.push(module, "99b03/f499C5qBVb5FCdxDf", "AppStateMachine")) {
         }
       }
     };
+    // 將事件轉發給目前的狀態
     D.prototype.dispatchEvent = function (p, j) {
       if (this.isStateRunning) {
         var l = this.currentAppState;
@@ -91,10 +96,12 @@ if (!cc._RF.push(module, "99b03/f499C5qBVb5FCdxDf", "AppStateMachine")) {
         }
       }
     };
+    // 銷毀狀態機
     D.prototype.destroy = function () {
       this._exitAppStateMachineCallback = undefined;
       this._getNextAppState = undefined;
     };
+    // 取得並進入下一個狀態
     D.prototype._evaluateState = function () {
       var p = this;
       if (this.isStateRunning) {
@@ -140,6 +147,7 @@ if (!cc._RF.push(module, "99b03/f499C5qBVb5FCdxDf", "AppStateMachine")) {
         }
       }
     };
+    // 結束狀態機並呼叫回呼
     D.prototype._exit = function () {
       if (!this.isStateEnd) {
         this._stateMachineStatus = T.End;

--- a/export/a/AudioAdapter.js
+++ b/export/a/AudioAdapter.js
@@ -54,12 +54,14 @@ if (!cc._RF.push(module, "5c3d2SrYLxJYqXl2p30apID", "AudioAdapter")) {
         setTimeout(this.load.bind(this), 0);
       }
     }
+    // 載入音訊資源
     _Y.prototype.load = function () {
       if (this._state !== k.AUDIO_ADAPTER_STATE.LOADED && this._state !== k.AUDIO_ADAPTER_STATE.LODING) {
         this._loader.load(this._src, this._onLoadComplete.bind(this));
         this._state = k.AUDIO_ADAPTER_STATE.LODING;
       }
     };
+    // 音訊載入完成時的處理
     _Y.prototype._onLoadComplete = function (W, q) {
       if (W) {
         this._emit(k.AUDIO_ADAPTER_EVENT.LOAD_ERROR, undefined, W.message || W);
@@ -76,6 +78,7 @@ if (!cc._RF.push(module, "5c3d2SrYLxJYqXl2p30apID", "AudioAdapter")) {
         }
       }
     };
+    // 釋放音訊資源
     _Y.prototype.unload = function () {
       if (this._state !== k.AUDIO_ADAPTER_STATE.UNLOADED) {
         if (this._state !== k.AUDIO_ADAPTER_STATE.LODING) {
@@ -91,6 +94,7 @@ if (!cc._RF.push(module, "5c3d2SrYLxJYqXl2p30apID", "AudioAdapter")) {
         }
       }
     };
+    // 播放音效，回傳實例 ID
     _Y.prototype.play = function (W) {
       var q = this;
       if (this._state !== k.AUDIO_ADAPTER_STATE.LOADED) {
@@ -151,6 +155,7 @@ if (!cc._RF.push(module, "5c3d2SrYLxJYqXl2p30apID", "AudioAdapter")) {
       this._emit(k.AUDIO_ADAPTER_EVENT.PLAY, P);
       return P;
     };
+    // 停止音效，可指定實例或全部停止
     _Y.prototype.stop = function (W) {
       if (this._state !== k.AUDIO_ADAPTER_STATE.LOADED) {
         throw Error("Audio Adapter :: stop : Attemp to stop not loaded audio!");
@@ -176,6 +181,7 @@ if (!cc._RF.push(module, "5c3d2SrYLxJYqXl2p30apID", "AudioAdapter")) {
         }
       }
     };
+    // 暫停音效播放
     _Y.prototype.pause = function (W) {
       if (typeof W == "number") {
         if ((S = this._sounds[W]) && S.playing) {
@@ -196,6 +202,7 @@ if (!cc._RF.push(module, "5c3d2SrYLxJYqXl2p30apID", "AudioAdapter")) {
         }
       }
     };
+    // 恢復音效播放
     _Y.prototype.resume = function (W) {
       if (typeof W == "number") {
         if ((S = this._sounds[W]) && S.paused) {
@@ -217,6 +224,7 @@ if (!cc._RF.push(module, "5c3d2SrYLxJYqXl2p30apID", "AudioAdapter")) {
       }
     };
     _Y.prototype.setMute = function (W, q) {
+      // 設定靜音狀態
       if (typeof q == "number") {
         if ((z = this._sounds[q]) && z.muted !== W) {
           z.muted = W;
@@ -243,6 +251,7 @@ if (!cc._RF.push(module, "5c3d2SrYLxJYqXl2p30apID", "AudioAdapter")) {
       }
       return this._mute;
     };
+    // 設定音量
     _Y.prototype.setVolume = function (W, q) {
       if (typeof q == "number") {
         if ((z = this._sounds[q]) && z.volume !== W) {
@@ -263,6 +272,7 @@ if (!cc._RF.push(module, "5c3d2SrYLxJYqXl2p30apID", "AudioAdapter")) {
         }
       }
     };
+    // 取得音量
     _Y.prototype.getVolume = function (W) {
       if (typeof W == "number") {
         var q = this._sounds[W];
@@ -274,6 +284,7 @@ if (!cc._RF.push(module, "5c3d2SrYLxJYqXl2p30apID", "AudioAdapter")) {
       }
       return this._volume;
     };
+    // 取得即時音量（淡入淡出使用）
     _Y.prototype.getInstantVolume = function (W) {
       var q = this._sounds[W];
       if (q) {
@@ -282,6 +293,7 @@ if (!cc._RF.push(module, "5c3d2SrYLxJYqXl2p30apID", "AudioAdapter")) {
         return 0;
       }
     };
+    // 對音效進行淡入淡出
     _Y.prototype.fade = function (W, q, S, z) {
       var f = this;
       if (this._state !== k.AUDIO_ADAPTER_STATE.LOADED) {
@@ -314,6 +326,7 @@ if (!cc._RF.push(module, "5c3d2SrYLxJYqXl2p30apID", "AudioAdapter")) {
         }
       }
     };
+    // 設定是否循環播放
     _Y.prototype.setLoop = function (W, q) {
       if (typeof q == "number") {
         if (z = this._sounds[q]) {
@@ -330,6 +343,7 @@ if (!cc._RF.push(module, "5c3d2SrYLxJYqXl2p30apID", "AudioAdapter")) {
         }
       }
     };
+    // 判斷是否循環播放
     _Y.prototype.isLoop = function (W) {
       if (typeof W == "number") {
         var q = this._sounds[W];
@@ -337,6 +351,7 @@ if (!cc._RF.push(module, "5c3d2SrYLxJYqXl2p30apID", "AudioAdapter")) {
       }
       return this._loop;
     };
+    // 設定播放速率
     _Y.prototype.setRate = function (W, q) {
       if (typeof q == "number") {
         if (z = this._sounds[q]) {
@@ -353,6 +368,7 @@ if (!cc._RF.push(module, "5c3d2SrYLxJYqXl2p30apID", "AudioAdapter")) {
         }
       }
     };
+    // 取得播放速率
     _Y.prototype.getRate = function (W) {
       if (typeof W == "number") {
         var q = this._sounds[W];
@@ -362,6 +378,7 @@ if (!cc._RF.push(module, "5c3d2SrYLxJYqXl2p30apID", "AudioAdapter")) {
       }
       return this._rate;
     };
+    // 判斷音效是否正在播放
     _Y.prototype.isPlaying = function (W) {
       if (typeof W == "number") {
         var q = this._sounds[W];
@@ -369,6 +386,7 @@ if (!cc._RF.push(module, "5c3d2SrYLxJYqXl2p30apID", "AudioAdapter")) {
       }
       return this._numberOfInstance > 0 && this._paused === false;
     };
+    // 取得音效總長度
     _Y.prototype.getDuration = function (W) {
       if (typeof W == "number") {
         var q = this._sounds[W];
@@ -380,9 +398,11 @@ if (!cc._RF.push(module, "5c3d2SrYLxJYqXl2p30apID", "AudioAdapter")) {
       }
       return 0;
     };
+    // 取得當前適配器狀態
     _Y.prototype.getState = function () {
       return this._state;
     };
+    // 取得指定實例的播放時間
     _Y.prototype.getCurrentTime = function (W) {
       var q = this._sounds[W];
       if (q) {
@@ -391,6 +411,7 @@ if (!cc._RF.push(module, "5c3d2SrYLxJYqXl2p30apID", "AudioAdapter")) {
         return 0;
       }
     };
+    // 跳到指定播放時間
     _Y.prototype.seek = function (W, q) {
       var S = this;
       if (this._state !== k.AUDIO_ADAPTER_STATE.LOADED) {
@@ -426,9 +447,11 @@ if (!cc._RF.push(module, "5c3d2SrYLxJYqXl2p30apID", "AudioAdapter")) {
         }
       }
     };
+    // 從池中取得可用的音效物件
     _Y.prototype.getAudioFromPool = function () {
       return this.factory.get() || new shell.WebAudio(this._clip);
     };
+    // 將音效物件回收至池中
     _Y.prototype.addAudioToPool = function (W) {
       W.reset();
       W.removeAll();
@@ -436,6 +459,7 @@ if (!cc._RF.push(module, "5c3d2SrYLxJYqXl2p30apID", "AudioAdapter")) {
         W.destroy();
       }
     };
+    // 預留立體聲調整函式
     _Y.prototype.stereo = function () {};
     _Y.getNewId = G;
     return _Y;

--- a/export/a/AudioAssetConfig.js
+++ b/export/a/AudioAssetConfig.js
@@ -6,6 +6,7 @@ if (!cc._RF.push(module, "a2c0633AVRPK7FGJDEUOXcO", "AudioAssetConfig")) {
   var T = require("ResourceLoader");
   var x = require("AudioManager");
   var L = [];
+  // 取得所有需載入的音效資源設定
   exports.getAudioAssetConfig = function () {
     if (L.length > 0) {
       return L;
@@ -14,6 +15,7 @@ if (!cc._RF.push(module, "a2c0633AVRPK7FGJDEUOXcO", "AudioAssetConfig")) {
         L.push({
           name: D,
           type: T.LoaderType.CUSTOM,
+          // 載入一般音效資源
           loadFunc: function (k, C) {
             x.loadAudio(x.GeneralAudioPool[D], function (u) {
               if (u) {
@@ -27,6 +29,7 @@ if (!cc._RF.push(module, "a2c0633AVRPK7FGJDEUOXcO", "AudioAssetConfig")) {
       L.push({
         name: "general_audio",
         type: T.LoaderType.CUSTOM,
+        // 載入通用音效集合
         loadFunc: function (D, k) {
           x.loadAudio(x.generalGameAudio, function (C) {
             if (C) {

--- a/export/a/AudioFactory.js
+++ b/export/a/AudioFactory.js
@@ -8,15 +8,19 @@ if (!cc._RF.push(module, "bf4b5cdVNdI7rQp2MPM3CWN", "AudioFactory")) {
       this.maxStackSound = T.MAX_STACK_SOUND;
       this._pool = [];
     }
+    // 將音效實例放回池中
     L.prototype.put = function (D) {
       return this._pool.length < this.maxStackSound && (this._pool.push(D), true);
     };
+    // 從池中取出音效實例
     L.prototype.get = function () {
       return this._pool.pop();
     };
+    // 取得池中目前的實例數量
     L.prototype.size = function () {
       return this._pool.length;
     };
+    // 銷毀池內所有音效並清空
     L.prototype.destroy = function () {
       this._pool.forEach(function (D) {
         D.destroy();

--- a/export/a/AudioManager.js
+++ b/export/a/AudioManager.js
@@ -33,6 +33,7 @@ if (!cc._RF.push(module, "9fcddj5MjVCo4eqgr0JYxNU", "AudioManager")) {
   var Z0;
   var Z1 = ["bgm_mg", "bgm_fs"];
   exports.generalGameAudio = Z0;
+  // 初始化音效系統並建立預設音效
   exports.init = function () {
     var ZR;
     Object.keys(ZR = Y).forEach(function (ZK) {
@@ -47,6 +48,7 @@ if (!cc._RF.push(module, "9fcddj5MjVCo4eqgr0JYxNU", "AudioManager")) {
     Z9(true);
     ZZ(true);
   };
+  // 註冊音效物件並依類型保存
   exports.registerAudio = function (ZR, ZK) {
     var Zg = ZK ? H.MUSIC : H.SOUND;
     if (w) {
@@ -57,6 +59,7 @@ if (!cc._RF.push(module, "9fcddj5MjVCo4eqgr0JYxNU", "AudioManager")) {
     W[Zg].push(ZR);
     return Zg;
   };
+  // 移除已註冊的音效
   exports.unregisterAudio = function (ZR, ZK) {
     var Zg = W[ZK];
     var ZT = Zg.indexOf(ZR);
@@ -65,6 +68,7 @@ if (!cc._RF.push(module, "9fcddj5MjVCo4eqgr0JYxNU", "AudioManager")) {
     }
     Zg.splice(ZT, 1);
   };
+  // 設定指定音效的音量
   exports.setAudioVolume = function (ZR, ZK) {
     if (!q[ZR] || !!Z0.isPlaying(q[ZR])) {
       if (Z0) {
@@ -72,6 +76,7 @@ if (!cc._RF.push(module, "9fcddj5MjVCo4eqgr0JYxNU", "AudioManager")) {
       }
     }
   };
+  // 對指定音效進行淡入淡出
   exports.fadeAudio = function (ZR, ZK, Zg, ZT) {
     if (!q[ZR] || !!Z0.isPlaying(q[ZR])) {
       if (Z0) {
@@ -81,11 +86,13 @@ if (!cc._RF.push(module, "9fcddj5MjVCo4eqgr0JYxNU", "AudioManager")) {
   };
   exports.isAudioPlaying = Z6;
   exports.playAudio = Z7;
+  // 停止指定音效
   exports.stopAudio = function (ZR, ZK = Z0) {
     if (Z6(ZR, ZK) && ZK) {
       ZK.stop(q[ZR]);
     }
   };
+  // 遊戲開始後開啟音效控制
   exports.toggleAudioGameStarted = function () {
     w = true;
     Z9(!j.settingMenuHelper.soundEnable);
@@ -93,6 +100,7 @@ if (!cc._RF.push(module, "9fcddj5MjVCo4eqgr0JYxNU", "AudioManager")) {
   };
   exports.toggleMusicMuted = Z9;
   exports.toggleEffectMuted = ZZ;
+  // 交叉淡入淡出兩段音樂
   exports.crossFadeAudio = function (ZR, ZK, Zg = 1) {
     ZK.setVolume(0);
     ZK.play();
@@ -106,6 +114,7 @@ if (!cc._RF.push(module, "9fcddj5MjVCo4eqgr0JYxNU", "AudioManager")) {
       });
     }
   };
+  // 更新所有音效的播放速率
   exports.updatePlayRate = function (ZR) {
     for (var ZK in W) {
       if (W[ZK]) {
@@ -116,6 +125,7 @@ if (!cc._RF.push(module, "9fcddj5MjVCo4eqgr0JYxNU", "AudioManager")) {
       }
     }
   };
+  // 載入指定音效資源
   exports.loadAudio = function (ZR, ZK) {
     function Zg() {
       ZR.off("loaderror", ZT);
@@ -133,20 +143,24 @@ if (!cc._RF.push(module, "9fcddj5MjVCo4eqgr0JYxNU", "AudioManager")) {
     ZR.once("loaderror", ZT);
     return ZR.load();
   };
+  // 釋放音效池中的所有資源
   exports.releaseAudioPool = function (ZR) {
     Object.keys(ZR).forEach(function (ZK) {
       ZI(ZR[ZK]);
     });
   };
   exports.releaseAudio = ZI;
+  // 設定贏得次數
   exports.setWinCount = function (ZR) {
     X = ZR;
   };
+  // 取得目前贏得次數
   exports.getWinCount = function () {
     return X;
   };
   cc._RF.pop();
 }
+// 建立一般音效物件
 function Z2(ZR, ZK = H.SOUND) {
   var Zg = {
     preload: false,
@@ -159,6 +173,7 @@ function Z2(ZR, ZK = H.SOUND) {
     return new V.default(Zg, ZK);
   }
 }
+// 建立具音效片段資訊的音效物件
 function Z3(ZR, ZK = H.SOUND, Zg) {
   var ZT = {
     preload: false,
@@ -172,9 +187,11 @@ function Z3(ZR, ZK = H.SOUND, Zg) {
     return new V.default(ZT, ZK);
   }
 }
+// 取得音效實際資源路徑
 function Z4(ZR) {
   return J + ZR;
 }
+// 播放或暫停指定音效並管理 ID
 function Z5(ZR, ZK, Zg, ZT, Zx) {
   if (ZR.hasOwnProperty(Zg)) {
     if (Zx) {
@@ -189,17 +206,21 @@ function Z5(ZR, ZK, Zg, ZT, Zx) {
     }
   }
 }
+// 檢查音效是否正在播放
 function Z6(ZR, ZK = Z0) {
   return q[ZR] && ZK.isPlaying(q[ZR]);
 }
+// 播放通用音效
 function Z7(ZR, ZK, Zg) {
   Z5(Q.GENERAL_AUDIO, Z0, ZR, ZK, Zg);
 }
+// 暫停通用音效
 function Z8(ZR, ZK = Z0) {
   if (Z6(ZR, ZK) && ZK) {
     ZK.pause(q[ZR]);
   }
 }
+// 切換音樂靜音
 function Z9(ZR = false) {
   if (W[H.MUSIC]) {
     W[H.MUSIC].map(function (ZK) {
@@ -207,6 +228,7 @@ function Z9(ZR = false) {
     });
   }
 }
+// 切換音效靜音
 function ZZ(ZR = false) {
   if (W[H.SOUND]) {
     W[H.SOUND].map(function (ZK) {
@@ -214,9 +236,11 @@ function ZZ(ZR = false) {
     });
   }
 }
+// 卸載指定音效資源
 function ZI(ZR) {
   return ZR.unload();
 }
+// 進入背景時暫停所有音效
 function Zd() {
   if (!U) {
     U = true;
@@ -235,6 +259,7 @@ function Zd() {
     });
   }
 }
+// 回到前景時恢復被暫停的音效
 function ZO() {
   if (U) {
     U = false;

--- a/export/a/AutoSpinHandler.js
+++ b/export/a/AutoSpinHandler.js
@@ -5,12 +5,15 @@ if (!cc._RF.push(module, "6a62eVFmd1Ng5ghvfVXBlUq", "AutoSpinHandler")) {
   exports.exitAutoSpin = exports.decrementAutoSpinCount = exports.resetAutoSpinCount = exports.startAutoSpin = exports.getAutoSpinCount = exports.shouldAutoSpin = undefined;
   var T = require("GameEventHandler");
   var x = -1;
+  // 判斷是否需要自動旋轉
   exports.shouldAutoSpin = function () {
     return x > 0;
   };
+  // 取得剩餘自動旋轉次數
   exports.getAutoSpinCount = function () {
     return x;
   };
+  // 開始自動旋轉並進入自動模式
   exports.startAutoSpin = function (D, k, C) {
     x = D;
     k.enterAutoSpinMode(D, C);
@@ -18,19 +21,23 @@ if (!cc._RF.push(module, "6a62eVFmd1Ng5ghvfVXBlUq", "AutoSpinHandler")) {
       L(k);
     });
   };
+  // 重設自動旋轉計數
   exports.resetAutoSpinCount = function () {
     x = -1;
   };
+  // 自動旋轉結束時遞減計數
   exports.decrementAutoSpinCount = function (D) {
     x -= 1;
     D.updateAutoSpinCount(x);
   };
+  // 結束自動旋轉模式
   exports.exitAutoSpin = function (D) {
     L(D);
     T.emitAutoplayStopped();
   };
   cc._RF.pop();
 }
+// 離開自動旋轉模式並重設計數
 function L(D) {
   x = -1;
   D.exitAutoSpinMode();


### PR DESCRIPTION
## Summary
- add Traditional Chinese comments to functions across export/a modules
- document purposes of export/a files in `export.md`

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b87749d4832d8e03e3dca2acade1